### PR TITLE
add: Railsサーバー用のGoogle Artifact Registryリポジトリを追加

### DIFF
--- a/infra/rails-server.tf
+++ b/infra/rails-server.tf
@@ -1,3 +1,10 @@
+resource "google_artifact_registry_repository" "rails_repo" {
+  location      = var.region
+  repository_id = "rails-server"
+  format        = "DOCKER"
+  description   = "Rails server container images"
+}
+
 resource "google_cloud_run_service" "rails_server" {
     name     = "rails-server"
     location = var.region


### PR DESCRIPTION
1. 最初の問題: Cloud SQL Admin API無効

  エラー: Error 404: The Cloud SQL instance does not exist., instanceDoesNotExist
  原因: Cloud SQL Admin APIが無効
  解決:
  gcloud services enable sqladmin.googleapis.com --project=bandbrother2

  2. Terraform設定の改善

  問題: 警告とリソース依存関係の問題
  解決:
  - cloudsql.tfでpasswordをpassword_woに変更 (警告解消)
  - depends_on = [google_sql_database_instance.main]を追加 (依存関係明示)

  3. GitHub Actions環境変数不足

  問題: terraform planでvar.database_nameで停止
  原因: GitHub ActionsでTerraform変数が未設定
  解決: .github/workflows/deploy.ymlに環境変数を追加:
  env:
    TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
    TF_VAR_database_name: ${{ secrets.TF_VAR_DATABASE_NAME }}
    # その他の変数も追加

  4. IAM権限不足

  エラー: Error 403: Permission denied
  原因: サービスアカウントに必要な権限が不足
  解決: 以下の権限を追加:
  gcloud projects add-iam-policy-binding bandbrother2 \
    --member="serviceAccount:bandbrother2@bandbrother2.iam.gserviceaccount.com" \
    --role="roles/cloudsql.admin"
  # artifactregistry.admin, run.adminも同様に追加

  5. 既存リソースとの競合

  エラー: Error 409: Resource already exists
  原因: 手動作成されたリソースがTerraform状態に未登録
  解決: 既存リソースをTerraformにインポート:
  terraform import google_sql_database_instance.main rails-db
  terraform import google_sql_database.db rails-db/bandbrother2
  terraform import google_artifact_registry_repository.rails_repo projects/bandbrother2/locations/asia-northeast1/repositories/rails-server

  6. 最終的な状態同期

  実行: terraform refreshでリソース状態を最新化

  結果: 全9リソースがTerraformで適切に管理される状態になり、GitHub Actionsでの自動デプロイが可能になりました。

⏺ Terraformで管理している9リソース:

⏺ Bash(terraform state list)
  ⎿  google_artifact_registry_repository.rails_repo    
     google_artifact_registry_repository.websocket_repo
     google_cloud_run_service.rails_server
     … +6 lines (ctrl+r to expand)

⏺ 9つのリソース詳細:

  1. google_artifact_registry_repository.rails_repo - Railsサーバー用Dockerリポジトリ
  2. google_artifact_registry_repository.websocket_repo - Go WebSocket用Dockerリポジトリ
  3. google_cloud_run_service.rails_server - RailsサーバーのCloud Runサービス
  4. google_cloud_run_service.websocket_server - Go WebSocketのCloud Runサービス
  5. google_cloud_run_service_iam_member.invoker - WebSocketサービス用パブリックアクセス権限
  6. google_cloud_run_service_iam_member.public_invoker - Railsサーバー用パブリックアクセス権限
  7. google_sql_database.db - PostgreSQLデータベース (bandbrother2)
  8. google_sql_database_instance.main - Cloud SQLインスタンス (rails-db)
  9. google_sql_user.user - データベースユーザー (bb2_user)

  これらが全てTerraformで管理されています。